### PR TITLE
Wip/ggiordano@phytec.com/tisdk compatibility

### DIFF
--- a/recipes-images/images/phytec-lumissil-greenphy-image.bb
+++ b/recipes-images/images/phytec-lumissil-greenphy-image.bb
@@ -1,4 +1,4 @@
-require recipes-images/images/phytec-headless-image.bb
+include recipes-images/images/phytec-headless-image.bb
 
 SUMMARY = "This image is designed to install all software required for \
 	   the Lumissil Green PHY demo."

--- a/recipes-images/images/tisdk-lumissil-greenphy-image.bb
+++ b/recipes-images/images/tisdk-lumissil-greenphy-image.bb
@@ -1,0 +1,13 @@
+include recipes-core/images/tisdk-default-image.bb
+
+SUMMARY = "This image is designed to install all software required for \
+	   the Lumissil Green PHY demo."
+
+LICENSE = "MIT"
+
+IMAGE_INSTALL += "\
+    cg5317-utils \
+    open-plc-utils \
+    lms-eth2spi \
+    kernel-module-lms-eth2spi \
+"

--- a/recipes-utils/cg5317-utils/cg5317-utils.bb
+++ b/recipes-utils/cg5317-utils/cg5317-utils.bb
@@ -3,8 +3,6 @@ DESCRIPTION = "Layer includes the services to initialize CG5317 in host loading 
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://../COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
-ROOT_HOME = "/root"
-
 SRC_URI = " \
 	file://cg5317-bringup.service \
 	file://cg5317-host.service \
@@ -18,36 +16,35 @@ SRC_URI = " \
 	file://spi_cco_config.bin \
 "
 
-# libgpiod_2.x.x deploys libgpiod.so.3
 RDEPENDS:${PN}:append = "libgpiod (<= 2.0.0)"
 
 do_install() {
+	# Install systemd services
 	install -d ${D}${sysconfdir}/systemd/system/
 	install -m 0644 ${WORKDIR}/cg5317-bringup.service ${D}${sysconfdir}/systemd/system
 	install -m 0644 ${WORKDIR}/cg5317-host.service ${D}${sysconfdir}/systemd/system
 
+	# Enable services for multi-user target
+	install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants
+	ln -sf ../cg5317-bringup.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
+	ln -sf ../cg5317-host.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
+
+	# Install configuration files
 	install -m 0644 ${WORKDIR}/evse.ini ${D}${sysconfdir}/
 	install -m 0644 ${WORKDIR}/pev.ini ${D}${sysconfdir}/
 
-	install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants
-	ln -sf ${D}${sysconfdir}/systemd/system/cg5317-bringup.service \
-		${D}${sysconfdir}/systemd/system/multi-user.target.wants/
-	ln -sf ${D}${sysconfdir}/systemd/system/cg5317-host.service \
-		${D}${sysconfdir}/systemd/system/multi-user.target.wants/
+	# Install examples directory
+	install -d ${D}/root/examples
+	cp -r ${WORKDIR}/examples/* ${D}/root/examples/
+	find ${D}/root/examples -type f -exec chmod +x {} +
 
-	install -d ${D}${sysconfdir}/systemd/system/default.target.wants
-
-	install -d ${D}${ROOT_HOME}
-	cp -r ${WORKDIR}/examples ${D}${ROOT_HOME}
-	find ${D}${ROOT_HOME}/examples -type f -exec chmod +x {} +
-
-	install -d ${D}/usr/lib/firmware
-	install -m 0644 ${WORKDIR}/config.bin ${D}/usr/lib/firmware
-	install -m 0644 ${WORKDIR}/spi_sta_config.bin ${D}/usr/lib/firmware
-	install -m 0644 ${WORKDIR}/spi_cco_config.bin ${D}/usr/lib/firmware
-	install -m 0644 ${WORKDIR}/FW.bin ${D}/usr/lib/firmware
+	# Install firmware files
+	install -d ${D}${nonarch_base_libdir}/firmware
+	install -m 0644 ${WORKDIR}/config.bin ${D}${nonarch_base_libdir}/firmware
+	install -m 0644 ${WORKDIR}/spi_sta_config.bin ${D}${nonarch_base_libdir}/firmware
+	install -m 0644 ${WORKDIR}/spi_cco_config.bin ${D}${nonarch_base_libdir}/firmware
+	install -m 0644 ${WORKDIR}/FW.bin ${D}${nonarch_base_libdir}/firmware
 }
 
-FILES:${PN} += "${base_libdir}/systemd/system"
-FILES:${PN} += "/usr/lib/firmware/*"
-FILES:${PN} += "${ROOT_HOME}/**"
+FILES:${PN} += "${nonarch_base_libdir}/firmware/*"
+FILES:${PN} += "/root/examples"

--- a/recipes-utils/cg5317-utils/files/cg5317-bringup.service
+++ b/recipes-utils/cg5317-utils/files/cg5317-bringup.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=cg5317 Interface Bringup Service
-After=network.target
+After=network.target sys-subsystem-net-devices-seth0.device
+Wants=sys-subsystem-net-devices-seth0.device
 
 [Service]
 ExecStart=/usr/sbin/ip link set seth0 up


### PR DESCRIPTION
This patch set makes the repo compatible with TISDK Yocto builds.
- Adds an image for building the tisdk. This was used for building the meta-ksp5055 image.
- Updates phytec-lumissil-greenphy-image to allow building without PHYTEC's BSP dependencies.
- Update the cg5317-bringup service to wait for SETH0 device to be present. Required for TISDK.
- Updated the cg5317-utils.bb recipe to be fix warnings and clarify comments. Deploys the same as the previous recipe.

This set was tested against both PHYTEC and TISDK Yocto builds.
